### PR TITLE
chore(direct-file): remove unused package-lock.json

### DIFF
--- a/direct-file/package-lock.json
+++ b/direct-file/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "direct-file",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# what this PR does

Removes `direct-file/package-lock.json` because it doesn't appear to be used anywhere, and doesn't seem like it could possibly have a function without a paired `direct-file/package.json`.

## testing

I did not test anything around this but assume something would have a build failure if in CI if the file was needed.