### PR TITLE
Remove unused/outdated javax jaxb dependency

### DIFF
--- a/direct-file/backend/pom.xml
+++ b/direct-file/backend/pom.xml
@@ -30,10 +30,6 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <exclusions>

--- a/direct-file/boms/irs-spring-boot-starter-parent/pom.xml
+++ b/direct-file/boms/irs-spring-boot-starter-parent/pom.xml
@@ -25,7 +25,6 @@
         <aws-sdk.version>2.30.19</aws-sdk.version>
         <!-- https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-project-maven.html#sdk-as-dependency -->
         <directfile-bom.version>0.0.1-SNAPSHOT</directfile-bom.version>
-        <jaxb-api.version>2.3.1</jaxb-api.version>
         <logstash.version>7.4</logstash.version>
         <modelmapper.version>3.1.0</modelmapper.version>
         <modelmapper-module-record.version>1.0.0</modelmapper-module-record.version>
@@ -144,11 +143,6 @@
                 <groupId>net.logstash.logback</groupId>
                 <artifactId>logstash-logback-encoder</artifactId>
                 <version>${logstash.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>


### PR DESCRIPTION
This dependency caught my eye since `javax` -> `jakarta` was part of the spring boot 2 -> 3 migration.  

The managed library is only brought in as a dependency by `directfile-api`, and within that module's java code there appear to be no references to any classes within the bind library; the only javax.xml classes referenced are included within the jdk.  I initially planned to replace this library with `jakarta.xml.bind-api` but with the lack of usages removal seems suitable.